### PR TITLE
都道府県・市町村・町域のAPIを物件更新と物件一覧の検索に導入する。

### DIFF
--- a/django/RealEstate360/urls.py
+++ b/django/RealEstate360/urls.py
@@ -23,4 +23,5 @@ urlpatterns = [
         views.propertyinfo_inactive,
         name="propertyinfo_inactive",
     ),
+    path("get_properties/", views.get_properties, name="get_properties"),
 ]

--- a/django/estate/urls.py
+++ b/django/estate/urls.py
@@ -15,7 +15,6 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
-from RealEstate360 import views
 
 urlpatterns = [
     path("admin/", admin.site.urls),

--- a/django/templates/base.html
+++ b/django/templates/base.html
@@ -12,7 +12,8 @@
     <link href="https://fonts.googleapis.com/css2?family=BIZ+UDPGothic:wght@400;700&display=swap" rel="stylesheet">
 
     <!-- Bootstrap CDN読み込み -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
 
     <!-- staticフォルダ内のcss読み込み -->
     {% load static %}
@@ -30,20 +31,25 @@
         <div class="container">
 
             <div class="navbar-brand">
-                <img src="{% static 'img/web-header-logo.svg' %}" alt=""  width="85" height="48.1" class="navbar-brand__img">
+                <img src="{% static 'img/web-header-logo.svg' %}" alt="" width="85" height="48.1"
+                    class="navbar-brand__img">
             </div>
 
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+                data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false"
+                aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
             </button>
 
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav mx-auto">
                     <li class="nav-item ms-lg-5">
-                        <a class="nav-link active" aria-current="page" href="{% url 'RealEstate360:propertyinfos_list' %}">物件一覧</a>
+                        <a class="nav-link active" aria-current="page"
+                            href="{% url 'RealEstate360:propertyinfos_list' %}">物件一覧</a>
                     </li>
                     <li class="nav-item ms-lg-5">
-                        <a class="nav-link active" aria-current="page" href="{% url 'RealEstate360:propertyinfo_create' %}">新規登録</a>                
+                        <a class="nav-link active" aria-current="page"
+                            href="{% url 'RealEstate360:propertyinfo_create' %}">新規登録</a>
                     </li>
                 </ul>
 
@@ -51,7 +57,8 @@
                     <input class="serch-form form-control" type="search" placeholder="管理タグで検索" aria-label="Search">
                     <button class="serch-btn btn-secondary" type="submit">検索</button>
                 </form>
-                <button type="button" class="logout-btn btn-secondary flex-shrink-0 ms-auto my-sm-2"><a class="nav-link" href="{% url 'RealEstate360:logout' %}">ログアウト</a></button>
+                <button type="button" class="logout-btn btn-secondary flex-shrink-0 ms-auto my-sm-2"><a class="nav-link"
+                        href="{% url 'RealEstate360:logout' %}">ログアウト</a></button>
             </div>
         </div>
     </nav>
@@ -62,7 +69,10 @@
 
 
     <!-- Bootstrap JavaScript読み込み -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+        crossorigin="anonymous"></script>
+    {% block scripts %}{% endblock %}
 </body>
 
 </html>

--- a/django/templates/edit.html
+++ b/django/templates/edit.html
@@ -44,6 +44,16 @@
     {{ basic_information_form.property_name }}
   </div>
 
+  <select id="geoapi-prefectures" name="geoapi-prefectures">
+    <option value="都道府県を選択してください">都道府県を選択してください</option>
+  </select>
+  <select id="geoapi-cities" name="geoapi-cities">
+    <option value="市区町村名を選択してください">市区町村名を選択してください</option>
+  </select>
+  <select id="geoapi-towns" name="geoapi-towns">
+    <option value="町域を選択してください">町域を選択してください</option>
+  </select>
+
   <div class="mb-3">
     <label for="{{ basic_information_form.location.id_for_label }}" class="p-6 mb-2 bg-success text-white">
       {{ basic_information_form.location.label }}
@@ -216,4 +226,38 @@
   <button type="submit">更新する</button>
 </form>
 
+{% endblock %}
+
+{% block scripts %}
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+<script type="text/javascript" src="http://geoapi.heartrails.com/api/geoapi.js"></script>
+<script>
+
+  document.getElementById('geoapi-prefectures').addEventListener('change', function (e) {
+    const idLocation = document.getElementById('id_location');
+    idLocation.value = ""
+  });
+
+  document.getElementById('geoapi-cities').addEventListener('change', function (e) {
+    const idLocation = document.getElementById('id_location');
+    idLocation.value = ""
+  });
+
+  document.getElementById('geoapi-towns').addEventListener('change', function (e) {
+    const idLocation = document.getElementById('id_location');
+    const citiesSelect = document.getElementById('geoapi-cities');
+    var encodedCity = encodeURIComponent(citiesSelect.value);
+    var selectedTown = e.target.value;
+
+    fetch('http://geoapi.heartrails.com/api/json?method=getTowns&city=' + encodedCity)
+      .then(response => response.json())
+      .then(data => {
+        let json_obj = data.response.location.find(obj => obj.town === selectedTown);
+        if (json_obj) {
+          idLocation.value = `${json_obj.postal} ${json_obj.prefecture}${json_obj.city}${json_obj.town}`;
+          /* console.log(json_obj); */
+        }
+      });
+  });
+</script>
 {% endblock %}

--- a/django/templates/list.html
+++ b/django/templates/list.html
@@ -22,6 +22,16 @@
     </div>
 </div>
 
+<select id="geoapi-prefectures" name="geoapi-prefectures">
+    <option value="都道府県を選択してください">都道府県を選択してください</option>
+</select>
+<select id="geoapi-cities" name="geoapi-cities">
+    <option value="市区町村名を選択してください">市区町村名を選択してください</option>
+</select>
+<select id="geoapi-towns" name="geoapi-towns">
+    <option value="町域を選択してください">町域を選択してください</option>
+</select>
+
 <!-- 一覧リストの項目名 -->
 <div class="container-lg container-md container-sm">
     <div class="row list__title gx-sm-0 gx-md-1">
@@ -38,24 +48,76 @@
     </div>
 
     <!-- 物件リストの列 -->
-    {% for basic_information in basic_informations %}
-    <div class="row list__item gx-1">
-        <a href="{% url 'RealEstate360:propertyinfo_detail' basic_information.basic_information_id %}" class="d-flex">
-            <div class="col-4">
-                <p class="list__item--tagname">{{ basic_information.control_number }}</p>
-            </div>
-            <div class="col-4">
-                <p>{{ basic_information.property_name }}</p>
-            </div>
-            <div class="col-3">
-                <p>{{ basic_information.location }}</p>
-            </div>
-            <div class="col-1 list__item--arrow">
-                <img src="{% static 'img/web-arrow.svg' %}" alt="詳細ページを見る" width="12.5" height="25" class="web-arrow">
-            </div>
-        </a>
+    <div id="property-lists">
+        {% for basic_information in basic_informations %}
+        <div class="row list__item gx-1">
+            <a href="{% url 'RealEstate360:propertyinfo_detail' basic_information.basic_information_id %}"
+                class="d-flex">
+                <div class="col-4">
+                    <p class="list__item--tagname">{{ basic_information.control_number }}</p>
+                </div>
+                <div class="col-4">
+                    <p>{{ basic_information.property_name }}</p>
+                </div>
+                <div class="col-3">
+                    <p>{{ basic_information.location }}</p>
+                </div>
+                <div class="col-1 list__item--arrow">
+                    <img src="{% static 'img/web-arrow.svg' %}" alt="詳細ページを見る" width="12.5" height="25"
+                        class="web-arrow">
+                </div>
+            </a>
+        </div>
+        {% endfor %}
     </div>
-    {% endfor %}
 </div>
 
+{% endblock %}
+
+{% block scripts %}
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+<script type="text/javascript" src="http://geoapi.heartrails.com/api/geoapi.js"></script>
+<script>
+    function fetchProperties() {
+        var prefectureSelect = document.getElementById('geoapi-prefectures');
+        var citySelect = document.getElementById('geoapi-cities');
+        var townSelect = document.getElementById('geoapi-towns');
+        var selectedPrefecture = (prefectureSelect.selectedIndex != 0) ? prefectureSelect.value : "";
+        var selectedCity = (citySelect.selectedIndex != 0) ? citySelect.value : "";
+        var selectedTown = (townSelect.selectedIndex != 0) ? townSelect.value : "";
+
+        fetch('/get_properties/?prefecture=' + selectedPrefecture + '&city=' + selectedCity + '&town=' + selectedTown)
+            .then(response => response.json())
+            .then(data => {
+
+                var propertyLists = document.getElementById('property-lists');
+                propertyLists.innerHTML = '';  // 物件リストを一度空にする
+
+                data.forEach(property => {
+                    var listItem = `
+                        <div class="row list__item gx-1">
+                            <a href="/propertyinfo_detail/${property.basic_information_id}" class="d-flex">
+                                <div class="col-4">
+                                    <p class="list__item--tagname">${property.control_number}</p>
+                                </div>
+                                <div class="col-4">
+                                    <p>${property.property_name}</p>
+                                </div>
+                                <div class="col-3">
+                                    <p>${property.location}</p>
+                                </div>
+                                <div class="col-1 list__item--arrow">
+                                    <img src="/static/img/web-arrow.svg" alt="詳細ページを見る" width="12.5" height="25" class="web-arrow">
+                                </div>
+                            </a>
+                        </div>`;
+                    // 生成したHTMLを物件リストに追加
+                    propertyLists.innerHTML += listItem;
+                })
+            })
+    }
+    document.getElementById('geoapi-prefectures').addEventListener('change', fetchProperties);
+    document.getElementById('geoapi-cities').addEventListener('change', fetchProperties);
+    document.getElementById('geoapi-towns').addEventListener('change', fetchProperties);
+</script>
 {% endblock %}


### PR DESCRIPTION
都道府県・市町村・町域のAPI geoapiを物件更新と物件一覧の検索に導入。
物件更新(edit.htm) id_locationに3つのselectを組み合わせて郵便番号・都道府県・市町村・町域を自動入力。
物件一覧(list.html) 3つのselectからid_locationの検索文字列を生成。該当するものだけを抽出することにより、都道府県→市町村→町域で検索対象を絞り込める。